### PR TITLE
added countdown and standings page without countdown

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -75,8 +75,8 @@ export default function Home() {
         timeRemaining.minutes > 0 &&
         timeRemaining.minutes < 30 && (
           <p className="time-message">
-            Total counts are hidden for the last 30 minutes of the challenge!
-            We'll see you all at 10PM in Vil A B302 to announce the winner!
+            Total counts are hidden for the last 30 minutes of the challenge! We
+            will see you all at 10PM in Vil A B302 to announce the winner!
           </p>
         )}
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,45 @@
+"use client";
+
 import Chart from "@/components/Chart/Chart";
 import "./page.css";
+import { useEffect, useState } from "react";
 
 export default function Home() {
+  //countdown to update every second
+  // const [countdown, setCountdown] = useState(0);
+  const [timeRemaining, setTimeRemaining] = useState({
+    hours: 0,
+    minutes: 0,
+    seconds: 0,
+  });
+
+  useEffect(() => {
+    const targetDate = new Date("2024-09-12T22:00:00").getTime();
+
+    const updateCountdown = () => {
+      const now = new Date().getTime();
+      const difference = targetDate - now;
+
+      if (difference > 0) {
+        const hours = Math.floor(
+          (difference % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60),
+        );
+        const minutes = Math.floor(
+          (difference % (1000 * 60 * 60)) / (1000 * 60),
+        );
+        const seconds = Math.floor((difference % (1000 * 60)) / 1000);
+
+        setTimeRemaining({ hours, minutes, seconds });
+      } else {
+        setTimeRemaining({ hours: 0, minutes: 0, seconds: 0 });
+      }
+    };
+
+    const timer = setInterval(updateCountdown, 1000);
+
+    return () => clearInterval(timer);
+  }, []);
+
   return (
     <div className="page">
       <div className="headers">
@@ -13,7 +51,34 @@ export default function Home() {
           </span>
         </span>
       </div>
-      <Chart />
+      {
+        <div className="countdown">
+          <h2>Challenge ends in:</h2>
+          <div className="time">
+            <div className="time-box">
+              <span>{timeRemaining.hours}</span>
+              <span>Hours</span>
+            </div>
+            <div className="time-box">
+              <span>{timeRemaining.minutes}</span>
+              <span>Minutes</span>
+            </div>
+            <div className="time-box">
+              <span>{timeRemaining.seconds}</span>
+              <span>Seconds</span>
+            </div>
+          </div>
+        </div>
+      }
+      {(timeRemaining.hours > 0 || timeRemaining.minutes >= 30) && <Chart />}
+      {timeRemaining.hours == 0 &&
+        timeRemaining.minutes > 0 &&
+        timeRemaining.minutes < 30 && (
+          <p className="time-message">
+            Total counts are hidden for the last 30 minutes of the challenge!
+            We'll see you all at 10PM in Vil A B302 to announce the winner!
+          </p>
+        )}
     </div>
   );
 }

--- a/src/app/standings/page.css
+++ b/src/app/standings/page.css
@@ -39,38 +39,6 @@ tspan {
   fill: white;
 }
 
-.countdown h2 {
-  font-size: 1.6rem;
-  color: white;
-  text-align: center;
-}
-.time {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-direction: row;
-}
-
-.time-box {
-  margin: 1rem;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-direction: column;
-  color: white;
-}
-.time-box span:first-child {
-  font-size: 1.6rem;
-  font-weight: 600;
-  margin: 0;
-}
-
-.time-message {
-  font-size: 1.2rem;
-  font-weight: 600;
-  margin-top: 2rem;
-  color: white;
-}
 @media screen and (max-width: 768px) {
   h1 {
     font-size: 2rem;

--- a/src/app/standings/page.tsx
+++ b/src/app/standings/page.tsx
@@ -1,0 +1,19 @@
+import Chart from "@/components/Chart/Chart";
+import "./page.css";
+
+export default function Standings() {
+  return (
+    <div className="page">
+      <div className="headers">
+        <h1>Devs Kickoff</h1>
+        <span className="sub-head">
+          Send NetIDs to:{" "}
+          <span className="link-text">
+            https://bootcamp.hoyadevelopers.com/api/bootcamp/submitNetId
+          </span>
+        </span>
+      </div>
+      <Chart />
+    </div>
+  );
+}

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -3,6 +3,6 @@ import { createClient } from "@supabase/supabase-js";
 
 export const getDbClient = () =>
   createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_URL || "",
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "",
   );

--- a/src/utils/emails.ts
+++ b/src/utils/emails.ts
@@ -1,7 +1,7 @@
 // utils/emails.ts
 import { Resend } from "resend";
 
-const resend = new Resend(process.env.RESEND_API_KEY);
+const resend = new Resend(process.env.RESEND_API_KEY || "");
 export async function sendVerificationEmail(email: string, nonce: string) {
   // Ensures this function is only run server-side
   if (typeof window !== "undefined") {


### PR DESCRIPTION
I've added the countdown until 10PM and logic to hide the standings on the homepage if there are 30 minutes or less left in the challenge. We shouldn't need to do any manual updates tomorrow night - it will just hide on its own.

The standings are still available on the /standings page all the time.

Also, the || "" for the env variable lets you run it locally without errors (it won't render, but you can build).